### PR TITLE
修复列align属性无效，以及添加特殊列的行渲染事件

### DIFF
--- a/components/table/EditableCell.tsx
+++ b/components/table/EditableCell.tsx
@@ -18,7 +18,6 @@ type Props<T> = {
     editingType?: 'cell' | 'row'
     // 用户触发保存的信息
     onSave: (record: T, type: 'DELETE' | 'UPDATE' | 'CREATE') => Promise<boolean>
-    restProps?: any
     // 显示模式，点击编辑，或者直接显示
     inputModal?: 'click' | 'display'
     // 当前正在编辑的cell
@@ -147,13 +146,11 @@ export class EditableCell<T> extends React.Component<Props<T>, State>{
         return true
     }
 
-
-
     renderCell = ({ form }: { form: WrappedFormUtils }) => {
-        const { editingType, restProps, children, inputModal, column, currentEditorCell, rowIndex } = this.props
+        const { editingType, children, inputModal, column, currentEditorCell, rowIndex } = this.props
         const self = this
         this.form = form
-
+        const textAlign = column === undefined ?  undefined : column.align
         // 如果列允许编辑
         if (column !== undefined && column.isEditing) {
             if (inputModal === 'click') {
@@ -161,7 +158,9 @@ export class EditableCell<T> extends React.Component<Props<T>, State>{
                 if (!this.isEditing()) {
                     return (
                         <div
-                            {...restProps!}
+                            style={{
+                                textAlign
+                            }}
                             className={this.getClassName()}
                             onClick={() => {
                                 const currentKey = column.dataIndex! + rowIndex
@@ -221,7 +220,9 @@ export class EditableCell<T> extends React.Component<Props<T>, State>{
         // 否则返回空
         return (
             <div
-                {...restProps!}
+                style={{
+                    textAlign
+                }}
             >
                 {children}
             </div>

--- a/components/table/Table.less
+++ b/components/table/Table.less
@@ -1,8 +1,3 @@
-// 修复选择框，和body中的选择框不对齐的
-.ant-table-thead > tr > th.ant-table-selection-column, .ant-table-tbody > tr > td.ant-table-selection-column{
-    text-align: left;
-}
-
 // 编辑icon设置为鼠标手形状
 .kotomi-components-table-editor-icon {
     cursor: pointer;

--- a/components/table/ushio/table.ushio.tsx
+++ b/components/table/ushio/table.ushio.tsx
@@ -187,15 +187,15 @@ export const rowEditorTable = () => {
 
     let columns: ColumnProps<User>[] = [{
         dataIndex: '$index',
-        title: '#',
     }, {
         dataIndex: '$state',
         width: 100
     }, {
         dataIndex: 'name',
         title: 'name',
+        align: 'center',
         isEditing: true,
-        width: 100
+        width: 300
     }, {
         dataIndex: 'six',
         title: 'six',
@@ -258,6 +258,14 @@ export const rowEditorTable = () => {
                         console.log(record)
                         console.log(type)
                         return true
+                    },
+                    onBeforeRenderPromiseColumn:(record:User , column: ColumnProps<User> ,render: JSX.Element)=>{
+                        if(column.dataIndex === '$operating#edit'){
+                            if(record.id === '1 id 1'){
+                                return <></>
+                            }
+                        }
+                        return render
                     }
                 } as TableEvent<User>}
                 loadData={({ page, pageSize }: { page: number, pageSize: number, param?: any, sorter?: TableSorter }) => {


### PR DESCRIPTION
1.  列的align属性设置后表格body里面还是无法正常进行相应align列属性的问题。
2. 添加onBeforeRenderPromiseColumn来控制特殊列的渲染